### PR TITLE
Add residentKey option to enablePasskeys() for password manager compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,13 +500,23 @@ Enable passkey authentication using the `enablePasskeys()` method on the Breezy 
 
 ```php
 BreezyCore::make()
-    ->enablePasskeys( 
-        relyingPartyName: 'My App', // optionally, change the passkey's party name (default = APP_NAME)
-        relyingPartyId: 'https://my-app.com', // optionally, change the passkey's party id (default = APP_URL)
-        relyingPartyIcon: '/logo.png', // optionally, change the passkey's party icon 
-        scopeToPanel: true, // scope the passkeys only to the current panel (default = true)
+    ->enablePasskeys(
+        relyingPartyName: 'My App',    // optional — relying party name shown to the user (default: APP_NAME)
+        relyingPartyId: 'my-app.com',  // optional — relying party ID, must match the browser origin hostname (default: current host)
+        relyingPartyIcon: '/logo.png', // optional — icon URL shown by the authenticator
+        scopeToPanel: true,            // optional — scope passkeys to the current panel only (default: true)
+        autoPrompt: false,             // optional — automatically prompt for passkey on the login page (default: false)
+        residentKey: null,             // optional — controls passkey discoverability (default: no_preference)
     )
 ```
+
+> **Note on `residentKey`:** For full compatibility with password managers such as Bitwarden or 1Password, set `residentKey` to `RESIDENT_KEY_REQUIREMENT_REQUIRED`. Without this, passkeys may be registered as non-discoverable, meaning password managers cannot find them during authentication. Platform authenticators like Apple Keychain are more lenient and work regardless.
+>
+> Available values:
+> - `AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED` — discoverable, recommended for password manager compatibility
+> - `AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED` — discoverable if supported by the authenticator
+> - `AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_DISCOURAGED` — non-discoverable (hardware keys with limited storage)
+> - `null` / not set — no preference, authenticator decides (default)
 
 #### Additional Configuration
 If you want to customize the component or modify its behavior, you can override the passkeys component in the myProfileComponents method:

--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ BreezyCore::make()
         scopeToPanel: true,            // optional — scope passkeys to the current panel only (default: true)
         autoPrompt: false,             // optional — automatically prompt for passkey on the login page (default: false)
         residentKey: null,             // optional — controls passkey discoverability (default: no_preference)
+        authenticatorAttachment: null, // optional — restrict to platform or cross-platform authenticators (default: no preference)
+        userVerification: null,        // optional — require user verification (PIN/biometric) during registration and login (default: preferred)
     )
 ```
 
@@ -516,6 +518,20 @@ BreezyCore::make()
 > - `AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED` — discoverable, recommended for password manager compatibility
 > - `AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED` — discoverable if supported by the authenticator
 > - `AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_DISCOURAGED` — non-discoverable (hardware keys with limited storage)
+
+> **Note on `authenticatorAttachment`:** Controls whether registration is restricted to a specific authenticator type. Only applies to registration (not login).
+>
+> Available values:
+> - `AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_PLATFORM` — built-in authenticators only (e.g. Apple Keychain, Windows Hello)
+> - `AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM` — external authenticators only (e.g. security keys, phones)
+> - `null` — no preference (default)
+
+> **Note on `userVerification`:** Controls whether the authenticator must verify the user (PIN, biometric) during both registration and login.
+>
+> Available values:
+> - `AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED` — verification mandatory
+> - `AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED` — verification requested if supported (default)
+> - `AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_DISCOURAGED` — verification not requested
 > - `null` / not set — no preference, authenticator decides (default)
 
 #### Additional Configuration

--- a/src/Concerns/Plugin/HasPasskeys.php
+++ b/src/Concerns/Plugin/HasPasskeys.php
@@ -17,6 +17,7 @@ use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 
@@ -34,7 +35,9 @@ trait HasPasskeys
 
     protected bool $autoPromptPasskeys = false;
 
-    public function enablePasskeys(bool $condition = true, ?string $relyingPartyName = null, ?string $relyingPartyId = null, ?string $relyingPartyIcon = null, bool $scopeToPanel = true, bool $autoPrompt = false): static
+    protected ?string $residentKey = null;
+
+    public function enablePasskeys(bool $condition = true, ?string $relyingPartyName = null, ?string $relyingPartyId = null, ?string $relyingPartyIcon = null, bool $scopeToPanel = true, bool $autoPrompt = false, ?string $residentKey = null): static
     {
         $this->passkeys = $condition;
         $this->scopePasskeysToPanel = $scopeToPanel;
@@ -42,6 +45,7 @@ trait HasPasskeys
         $this->passkeyRelyingPartyId = $relyingPartyId ?? request()->getHost();
         $this->passkeyRelyingPartyIcon = $relyingPartyIcon;
         $this->autoPromptPasskeys = $autoPrompt;
+        $this->residentKey = $residentKey;
 
         return $this;
     }
@@ -69,6 +73,11 @@ trait HasPasskeys
     public function autoPromptPasskeys(): bool
     {
         return $this->autoPromptPasskeys;
+    }
+
+    public function residentKey(): ?string
+    {
+        return $this->residentKey;
     }
 
     public function passkeySerializer(): Serializer
@@ -105,6 +114,7 @@ trait HasPasskeys
             rp: $this->passkeyRelatedPartyEntity(),
             user: $this->passkeyGenerateUserEntity(),
             challenge: Str::random(),
+            authenticatorSelection: new AuthenticatorSelectionCriteria(residentKey: $this->residentKey()),
         );
 
         return $this->passkeySerializer()->serialize($options, 'json');

--- a/src/Concerns/Plugin/HasPasskeys.php
+++ b/src/Concerns/Plugin/HasPasskeys.php
@@ -37,7 +37,11 @@ trait HasPasskeys
 
     protected ?string $residentKey = null;
 
-    public function enablePasskeys(bool $condition = true, ?string $relyingPartyName = null, ?string $relyingPartyId = null, ?string $relyingPartyIcon = null, bool $scopeToPanel = true, bool $autoPrompt = false, ?string $residentKey = null): static
+    protected ?string $authenticatorAttachment = null;
+
+    protected ?string $userVerification = null;
+
+    public function enablePasskeys(bool $condition = true, ?string $relyingPartyName = null, ?string $relyingPartyId = null, ?string $relyingPartyIcon = null, bool $scopeToPanel = true, bool $autoPrompt = false, ?string $residentKey = null, ?string $authenticatorAttachment = null, ?string $userVerification = null): static
     {
         $this->passkeys = $condition;
         $this->scopePasskeysToPanel = $scopeToPanel;
@@ -46,6 +50,8 @@ trait HasPasskeys
         $this->passkeyRelyingPartyIcon = $relyingPartyIcon;
         $this->autoPromptPasskeys = $autoPrompt;
         $this->residentKey = $residentKey;
+        $this->authenticatorAttachment = $authenticatorAttachment;
+        $this->userVerification = $userVerification;
 
         return $this;
     }
@@ -78,6 +84,16 @@ trait HasPasskeys
     public function residentKey(): ?string
     {
         return $this->residentKey;
+    }
+
+    public function authenticatorAttachment(): ?string
+    {
+        return $this->authenticatorAttachment;
+    }
+
+    public function userVerification(): ?string
+    {
+        return $this->userVerification;
     }
 
     public function passkeySerializer(): Serializer
@@ -114,7 +130,11 @@ trait HasPasskeys
             rp: $this->passkeyRelatedPartyEntity(),
             user: $this->passkeyGenerateUserEntity(),
             challenge: Str::random(),
-            authenticatorSelection: new AuthenticatorSelectionCriteria(residentKey: $this->residentKey()),
+            authenticatorSelection: new AuthenticatorSelectionCriteria(
+                authenticatorAttachment: $this->authenticatorAttachment(),
+                userVerification: $this->userVerification() ?? AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED,
+                residentKey: $this->residentKey(),
+            ),
         );
 
         return $this->passkeySerializer()->serialize($options, 'json');
@@ -126,6 +146,7 @@ trait HasPasskeys
             challenge: Str::random(),
             rpId: $this->passkeyRelyingPartyId(),
             allowCredentials: [],
+            userVerification: $this->userVerification(),
         );
 
         return $this->passkeySerializer()->serialize($options, 'json');


### PR DESCRIPTION
## Problem

When registering passkeys, `generatePasskeyRegisterOptions()` creates `PublicKeyCredentialCreationOptions` without setting `authenticatorSelection`. This means the `residentKey` requirement defaults to `no_preference`, and many authenticators (including Bitwarden) register the credential as **non-discoverable**.

Non-discoverable passkeys are invisible to password managers during authentication — Bitwarden, 1Password and similar tools cannot find them because they were never stored as resident/discoverable credentials. Platform authenticators like Apple Keychain are more lenient and work regardless, which masks the issue during development.

> A passkey isn't a passkey unless it is both FIDO2 and discoverable. If it isn't discoverable, it isn't a passkey, it's just a FIDO2 credential.

## Solution

Adds an optional `residentKey` parameter to `enablePasskeys()`:

```php
->enablePasskeys(
    residentKey: \Webauthn\AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
)
```

The default remains `null` (previous behaviour, no `authenticatorSelection` sent) to avoid a breaking change. Relying parties that want full password manager compatibility should pass `RESIDENT_KEY_REQUIREMENT_REQUIRED`.

## Available values

| Value | Behaviour |
|-------|-----------|
| `RESIDENT_KEY_REQUIREMENT_REQUIRED` | Discoverable — recommended for Bitwarden/1Password compatibility |
| `RESIDENT_KEY_REQUIREMENT_PREFERRED` | Discoverable if supported by the authenticator |
| `RESIDENT_KEY_REQUIREMENT_DISCOURAGED` | Non-discoverable — for hardware keys with limited storage |
| `null` (default) | No preference, authenticator decides |

## Changes

- Added `?string $residentKey` property to `HasPasskeys`
- Added `residentKey` parameter to `enablePasskeys()`
- Added `residentKey()` accessor
- `generatePasskeyRegisterOptions()` passes `AuthenticatorSelectionCriteria` built from the value
- README updated with all options and a note on password manager compatibility